### PR TITLE
Don't check for type if you don't need to

### DIFF
--- a/sudoku/sudoku.py
+++ b/sudoku/sudoku.py
@@ -172,7 +172,7 @@ class Sudoku:
             blank_count = 0
             for row in self.board:
                 for i in range(len(row)):
-                    if type(row[i]) is not int or not 1 <= row[i] <= self.size:
+                    if not row[i] in range(1, self.size + 1):
                         row[i] = Sudoku._empty_cell_value
                         blank_count += 1
             if difficulty == -1:


### PR DESCRIPTION
checking for the type of arguments goes against pythons ducktyping philosophy.
Also using `type(x) is int` has a few strange side effects when compared to `isinstance(x, int)`.
(I am here because of one of those strange effects)
As we allow only allow a few very specific values for the cells of a sudoku why can just test for them.
This should be more robust.